### PR TITLE
PENG-6092: attempt to deal with race condition by returning success on duplication error

### DIFF
--- a/src/CoreServer.cpp
+++ b/src/CoreServer.cpp
@@ -358,10 +358,13 @@ void CoreServer::_setup_routes(const PrometheusConfig &prom_config)
             res.status = 404;
             j["error"] = "policy does not exists";
             res.set_content(j.dump(), "text/json");
+            _logger->info("delete: policy not found: {}", name);
             return;
         }
         try {
+            _logger->info("delete: removing policy: {}", name);
             _registry->policy_manager()->remove_policy(name);
+            _logger->info("delete: removed policy: {}", name);
             res.status = 200;
             res.set_content(j.dump(), "text/json");
         } catch (const std::exception &e) {

--- a/src/CoreServer.cpp
+++ b/src/CoreServer.cpp
@@ -353,7 +353,7 @@ void CoreServer::_setup_routes(const PrometheusConfig &prom_config)
     });
     _svr.Delete(fmt::format("/api/v1/policies/({})", AbstractModule::MODULE_ID_REGEX).c_str(), [&](const httplib::Request &req, httplib::Response &res) {
         json j = json::object();
-        auto name = req.matches[1];
+        std::string name = req.matches[1];
         if (!_registry->policy_manager()->module_exists(name)) {
             res.status = 404;
             j["error"] = "policy does not exists";

--- a/src/Policies.cpp
+++ b/src/Policies.cpp
@@ -53,7 +53,13 @@ std::vector<Policy *> PolicyManager::load(const YAML::Node &policy_yaml, bool si
         // serialized policy loads
         std::unique_lock lock(_load_mutex);
 
+        // Ensure policy name isn't already defined
         auto policy_name = _get_policy_name(it);
+        if (module_exists(policy_name)) {
+            // ignore
+            spdlog::get("visor")->warn("ignoring policy with name '{}' already defined", policy_name);
+            continue;
+        }
         // Input Section
         auto input_node = it->second["input"];
         auto [input_config, input_filter] = _registry->input_manager()->get_config_and_filter(input_node);
@@ -224,10 +230,6 @@ std::string PolicyManager::_get_policy_name(YAML::const_iterator it)
     spdlog::get("visor")->info("policy [{}]: parsing", policy_name);
     if (!it->second.IsMap()) {
         throw PolicyException("expecting policy configuration map");
-    }
-    // Ensure policy name isn't already defined
-    if (module_exists(policy_name)) {
-        throw PolicyException(fmt::format("policy with name '{}' already defined", policy_name));
     }
 
     // Policy kind defines schema

--- a/src/tests/test_policies.cpp
+++ b/src/tests/test_policies.cpp
@@ -3,8 +3,8 @@
 #pragma GCC diagnostic push
 #pragma GCC diagnostic ignored "-Wmissing-declarations"
 #endif
-#include "inputs/static_plugins.h"
 #include "handlers/static_plugins.h"
+#include "inputs/static_plugins.h"
 #ifdef __GNUC__
 #pragma GCC diagnostic pop
 #endif
@@ -901,7 +901,9 @@ TEST_CASE("Policies", "[policies]")
 
         REQUIRE_NOTHROW(registry.tap_manager()->load(config_file["visor"]["taps"]));
         REQUIRE_NOTHROW(registry.policy_manager()->load(config_file["visor"]["policies"]));
-        REQUIRE_THROWS_WITH(registry.policy_manager()->load(config_file["visor"]["policies"]), "policy with name 'default_view' already defined");
+        // tolerated for the time being
+        REQUIRE_NOTHROW(registry.policy_manager()->load(config_file["visor"]["policies"]));
+        // REQUIRE_THROWS_WITH(registry.policy_manager()->load(config_file["visor"]["policies"]), "policy with name 'default_view' already defined");
 
         REQUIRE(registry.policy_manager()->module_exists("default_view"));
         auto [policy, lock] = registry.policy_manager()->module_get_locked("default_view");


### PR DESCRIPTION
In some cases the orb-agent receives the same policy twice from the gRPC server, so it attempts to delete and reapply: in the pktvisor logs we don't see the delete, successful or not, but the second apply throws an error which causes the orb-agent to classify the policy as failed.
Ideally the orb-agent shouldn't try to reapply the same policy until it can at least confirm it failed, but I don't want to create yet another fork so I want to test if there is a simpler way to deal with the situation: e.g. if the second apply returns a success the orb-agent might start pulling data from it.